### PR TITLE
Stores can be created and updated

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -37,7 +37,7 @@ export default function Navbar() {
           {
             profile.store ?
               <>
-                <Link href={`/stores/${profile.store.id}`}><a className="navbar-item">View Your Store</a></Link>
+                <Link href={`/stores/${profile.store.id}`} className="navbar-item">View Your Store</Link>
                 <Link href="/products/new" className="navbar-item">Add a new Product</Link>
               </>
               :


### PR DESCRIPTION
## Description of PR that completes issue

Fixed an error in the navigation menu by removing the `<a></a>` tags in order to properly handle routing for users who wish to create or view stores.

## Changes

- Removed `<a></a>` tags that were causing a navigation error.

## Testing

1. **Register a new user**

2. **Click on the Profile dropdown and select "Interested in selling?" to create a new store**  
   - You should be routed to `/stores/new`
   - Write a name and description and click "create"
   - When you click back on the profile dropdown, you should now see "View your store", click on that and verify that you are routed to `/stores/{store id}` and see the name and description for the store.
   - Click on "Edit Store" and you should be directed to `/stores/{store id}/edit` and see the edit form.
   - Change the name and description of the store and click "Save", you should be routed back to the store view and see the new name and description displayed.

## Related Issues

- Fixes #20