### PR TITLE
Fixed productview breaking on refresh 

### DIFF
--- a/components/rating/card.js
+++ b/components/rating/card.js
@@ -1,11 +1,17 @@
+import { useEffect } from 'react';
 import { Rating } from 'react-simple-star-rating'
 
 export function RatingCard({ rating }) {
+  const [showRating, setShowRating] = useState(false);
+  useEffect(() => {
+    setShowRating(true)
+  }, [])
+
   return (
     <div className="tile is-child">
       <article className="media box is-align-items-center">
         <figure className="media-left">
-          <Rating initialValue={rating.score} readonly={true} />
+          {showRating && <Rating initialValue={rating.score} readonly={true} />}
         </figure>
         <div className="media-content">
           <div className="content">

--- a/components/rating/form.js
+++ b/components/rating/form.js
@@ -1,9 +1,10 @@
 import { Rating } from 'react-simple-star-rating'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export default function RatingForm({ saveRating }) {
   const [rating, setRating] = useState(0)
   const [comment, setComment] = useState("")
+  const [showRating, setShowRating] = useState(false)
   
   const submitRating = () => {
     const outOf5 = rating/20
@@ -13,13 +14,15 @@ export default function RatingForm({ saveRating }) {
     })
   }
 
+  useEffect(()=>{setShowRating(true)}, [])
+
 
 
   return (
     <div className="tile is-child ">
       <article className="media box">
         <figure className="media-left">
-          <Rating onClick={setRating} ratingValue={rating} />
+          {showRating && <Rating onClick={setRating} ratingValue={rating} />}
         </figure>
         <div className="media-content">
           <div className="field">


### PR DESCRIPTION
# What?

The product detail view (`/product/id`) was breaking on refresh and throwing the following bug: 
"ReferenceError: Window is not defined on refresh".

# How
- Looked at the Next.js error log. Origin of error is the react-simple-star-rating component.
- Googled: "react-simple-star-rating referenceerror: window is not defined on refresh"
- Reading through documentation and search results, appears that the component is using server-side rendering and trying to push the component to the browser's window object before the window object has fully loaded.
- Added showRating state and a useEffect that updates the showRating state after initial render.
- Added inline conditional rendering around the Rating component that waits for showRating = True

# Testing
- Go to a product detail view
- hit refresh
- do you get an error?

# Related Issues
#41 
