### PR TITLE
Bugfix/navbar overlap

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -74,6 +74,7 @@ export default function Navbar() {
   }
 
   return (
+    <section className='section'>
 
     <nav className="navbar mb-3 is-warning px-5 is-fixed-top is-top" role="navigation" aria-label="main navigation">
       <div className="navbar-brand">
@@ -102,5 +103,6 @@ export default function Navbar() {
         </div>
       </div>
     </nav>
+    </section>
   )
 }

--- a/components/rating/card.js
+++ b/components/rating/card.js
@@ -1,11 +1,17 @@
+import { useEffect } from 'react';
 import { Rating } from 'react-simple-star-rating'
 
 export function RatingCard({ rating }) {
+  const [showRating, setShowRating] = useState(false);
+  useEffect(() => {
+    setShowRating(true)
+  }, [])
+
   return (
     <div className="tile is-child">
       <article className="media box is-align-items-center">
         <figure className="media-left">
-          <Rating initialValue={rating.score} readonly={true} />
+          {showRating && <Rating initialValue={rating.score} readonly={true} />}
         </figure>
         <div className="media-content">
           <div className="content">

--- a/components/rating/form.js
+++ b/components/rating/form.js
@@ -1,9 +1,10 @@
 import { Rating } from 'react-simple-star-rating'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export default function RatingForm({ saveRating }) {
   const [rating, setRating] = useState(0)
   const [comment, setComment] = useState("")
+  const [showRating, setShowRating] = useState(false)
   
   const submitRating = () => {
     const outOf5 = rating/20
@@ -13,13 +14,15 @@ export default function RatingForm({ saveRating }) {
     })
   }
 
+  useEffect(()=>{setShowRating(true)}, [])
+
 
 
   return (
     <div className="tile is-child ">
       <article className="media box">
         <figure className="media-left">
-          <Rating onClick={setRating} ratingValue={rating} />
+          {showRating && <Rating onClick={setRating} ratingValue={rating} />}
         </figure>
         <div className="media-content">
           <div className="field">


### PR DESCRIPTION
# What?
The navbar was overlapping the top of the page view. This was most noticeable in the product detail view `/products/id`.

# How? 
- Looked at the <NavBar /> component. Experimented with removing some classNames until navbar was impacted. 
- Googled: "bulma navbar overlapping a page". First result is a [stackoverflow question](https://stackoverflow.com/questions/54887534/bulma-navbar-overlaps-main-section) with the same issue. 
- Added a <section className='section"> tag around the <nav> tags. This solved the issue.
- [Bulma has a solution for this issue in their documentation](https://bulma.io/documentation/components/navbar/#fixed-navbar), but given our use of Next.js, this solution did not appear to fit our context. 

# Related Issues: 
#59 