### PR TITLE
images now properly pull from the api's media/products folder

### DIFF
--- a/components/product/card.js
+++ b/components/product/card.js
@@ -1,12 +1,15 @@
 import Link from 'next/link'
+import Image from 'next/image'
 
 export function ProductCard({ product, removeProduct, isOwner = false, width="is-one-fifth", noButtons }) {
+  const image_src = 'http://localhost:8000' + product.image_path
   return (
     <div className={`column ${width}`}>
       <div className="card">
         <div className="card-image">
           <figure className="image is-4by3">
-            <img src={product.image_path} alt="Placeholder image"></img>
+            {/* <Image src={product.image_path} alt="Placeholder image" width={100} height={100} /> */}
+            <img src={image_src} alt="Placeholder image"></img>
           </figure>
         </div>
         <header className="card-header">

--- a/components/product/card.js
+++ b/components/product/card.js
@@ -8,7 +8,6 @@ export function ProductCard({ product, removeProduct, isOwner = false, width="is
       <div className="card">
         <div className="card-image">
           <figure className="image is-4by3">
-            {/* <Image src={product.image_path} alt="Placeholder image" width={100} height={100} /> */}
             <img src={image_src} alt="Placeholder image"></img>
           </figure>
         </div>

--- a/components/product/detail.js
+++ b/components/product/detail.js
@@ -46,7 +46,7 @@ export function Detail({ product, like, unlike }) {
         <div className="tile is-parent">
           <article className="tile is-child">
             <figure className="image is-4by3">
-              <img src="https://bulma.io/images/placeholders/640x480.png"></img>
+              <img src={product.image_path}></img>
             </figure>
           </article>
         </div>


### PR DESCRIPTION
# Overview
Placeholder images were not displaying properly. 

# How
In the Products List View: Added string concatenation to account for the port difference. Appends 'http://localhost:8000' to the product object's image_path field. 

In Products Detail View: Accessed the product.image_path field directly. 

# Test
Add your own ridiculous place holder images to your media/product folder in your API project. 
They should be titled 'vehicle.png' 'clothing.png' 'tools.png'

![Screenshot 2025-04-09 at 15 35 33](https://github.com/user-attachments/assets/71b54e26-cf3c-4c5b-80af-827a06c170ab)

![Screenshot 2025-04-09 at 15 39 16](https://github.com/user-attachments/assets/589a9494-445e-4b1c-b79e-6788b901546e)
