### PR TITLE
Bug/complete order

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -1,4 +1,4 @@
-import { fetchWithResponse } from './fetcher'
+import { fetchWithoutResponse, fetchWithResponse } from './fetcher'
 
 export function getCart() {
   return fetchWithResponse('profile/cart', {
@@ -24,5 +24,14 @@ export function completeCurrentOrder(orderId, paymentTypeId) {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({"payment_type": paymentTypeId})
+  })
+}
+
+export function deleteCurrentOrder(orderId) {
+  return fetchWithoutResponse(`orders/${orderId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Token ${localStorage.getItem('token')}`
+    }
   })
 }

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -5,7 +5,7 @@ import Layout from '../components/layout'
 import Navbar from '../components/navbar'
 import CartDetail from '../components/order/detail'
 import CompleteFormModal from '../components/order/form-modal'
-import { completeCurrentOrder, getCart } from '../data/orders'
+import { completeCurrentOrder, deleteCurrentOrder, getCart } from '../data/orders'
 import { getPaymentTypes } from '../data/payment-types'
 import { removeProductFromOrder } from '../data/products'
 
@@ -19,7 +19,7 @@ export default function Cart() {
     getCart().then(cartData => {
       if (cartData) {
         setCart(cartData)
-      } else {""}
+      } else {{}}
     })
   }
 
@@ -42,6 +42,12 @@ export default function Cart() {
     removeProductFromOrder(productId).then(refresh)
   }
 
+  const handleDeleteOrder = (orderId) => {
+    deleteCurrentOrder(orderId).then(() => {
+      setCart({})
+    })
+  }
+
   return (
     <>
       <CompleteFormModal
@@ -53,8 +59,11 @@ export default function Cart() {
       <CardLayout title="Your Current Order">
         <CartDetail cart={cart} removeProduct={removeProduct} />
         <>
-          <a className="card-footer-item" onClick={() => setShowCompleteForm(true)}>Complete Order</a>
-          <a className="card-footer-item">Delete Order</a>
+          {cart.lineitems && cart.lineitems.length > 0 ? (
+            <a className="card-footer-item" onClick={() => setShowCompleteForm(true)}>Complete Order</a>
+
+          ) : (<span className='card-footer-item is-disabled'>Complete Order</span>)}
+          <a className="card-footer-item" onClick={() => handleDeleteOrder(cart.id)}>Delete Order</a>
         </>
       </CardLayout>
     </>

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -19,7 +19,7 @@ export default function Cart() {
     getCart().then(cartData => {
       if (cartData) {
         setCart(cartData)
-      }
+      } else {""}
     })
   }
 

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -4,9 +4,11 @@ import Layout from '../components/layout'
 import Navbar from '../components/navbar'
 import Table from '../components/table'
 import { getOrders } from '../data/orders'
+import { getPaymentTypes } from '../data/payment-types'
 
 export default function Orders() {
   const [orders, setOrders] = useState([])
+  const [paymentTypes, setPaymentTypes] = useState([])
   const headers = ['Order Date', 'Total', 'Payment Method']
 
   useEffect(() => {
@@ -15,18 +17,26 @@ export default function Orders() {
         setOrders(ordersData)
       }
     })
+    getPaymentTypes().then(paymentData => {
+      setPaymentTypes(paymentData)
+    })
   }, [])
+
+  const ordersWithPaymentDetails = orders.map(order => {
+    const paymentDetails = paymentTypes.find(payment => payment.url == order.payment_type)
+    return {...order, payment_type_details: paymentDetails}
+  })
 
   return (
     <>
       <CardLayout title="Your Orders">
         <Table headers={headers}>
           {
-            orders.map((order) => (
+            ordersWithPaymentDetails.map((order) => (
               <tr key={order.id}>
                 <td>{order.completed_on}</td>
                 <td>${order.total}</td>
-                <td>{order.payment_type?.obscured_num}</td>
+                <td>{order.payment_type_details ? `${order.payment_type_details.merchant_name} - ${order.payment_type_details?.account_number}` : 'No Payment Method'}</td>
               </tr>
             ))
           }


### PR DESCRIPTION
# Implement Order Completion & Cart Deletion Features

## Changes

- Fixed the "Complete Order" functionality to properly handle the completion flow:
  - When a payment type is selected and "Complete Order" button is clicked, the order is now correctly marked as complete
  - Order now appears in "My Orders" view after completion
  - Cart is properly emptied after order completion
- Added "Delete Order" button functionality to remove all items from the cart at once
- Fixed bug when the cart is empty to prevent breaking the cart view
- Disabled "Complete Order" button when the cart is empty

## Testing

-Login as any user

-In profile dropdown (on right), click on the "Cart", if the cart is empty the "Complete Order" button should be disabled

-Add several items to cart

-Click "Complete Order" and select a payment type and continue

-Verify that you are navigated to the `my-orders` page view and the new order is displayed in the My Orders list view, along with past orders. All orders should display with the correct date, total, and payment type. Also verify by clicking back to the cart, that the cart is now empty again

-Add several items to cart again

-Click "Delete Order" and verify that all items are removed from the cart

## Related Issues

- Fixes #31 (Bug: Completing an order doesn't work)
- Fixes #30 (Feature: Deleting all items in cart)
- Fixes #33 