### PR TITLE
Feature/favorite store

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -44,7 +44,7 @@ export default function Navbar() {
               <Link href="/stores/new" className="navbar-item">Interested in selling?</Link>
           }
           <hr className="navbar-divider"></hr>
-          <a className="navbar-item" onClick={
+          <Link href='/login' className="navbar-item" onClick={
             () => {
               localStorage.removeItem('token')
               setIsLoggedIn(false)
@@ -52,7 +52,7 @@ export default function Navbar() {
             }}
           >
             Log out
-          </a>
+          </Link>
         </div>
       </div>
     )

--- a/components/store/card.js
+++ b/components/store/card.js
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { ProductCard } from '../product/card'
 
-export function StoreCard({ store, width= "is-half" }) {
+export function StoreCard({ store, showProductCards=true, width= "is-half" }) {
   return (
     <div className={`column ${width}`}>
       <div className="card">
@@ -22,7 +22,7 @@ export function StoreCard({ store, width= "is-half" }) {
               Products: {store.size}
             </span>
           </div>
-          
+          {showProductCards &&
           <div className="content">
             <p className="title is-5 has-text-centered mb-4">All Products</p>
             <div className="columns is-multiline is-mobile">
@@ -35,6 +35,7 @@ export function StoreCard({ store, width= "is-half" }) {
               ))}
             </div>
           </div>
+          }
         </div>
         
         <footer className="card-footer">

--- a/context/state.js
+++ b/context/state.js
@@ -10,7 +10,10 @@ export function AppWrapper({ children }) {
   const router = useRouter()
 
   useEffect(() => {
-    setToken(localStorage.getItem('token'))
+    const storedToken = localStorage.getItem('token')
+    if (storedToken){
+      setToken(storedToken)
+    }
   }, [])
 
   useEffect(() => {
@@ -24,8 +27,10 @@ export function AppWrapper({ children }) {
           }
         })
       }
+    }else {
+      setProfile({})
     }
-  }, [token])
+  }, [token, router.pathname])
 
   return (
     <AppContext.Provider value={{ profile, token, setToken, setProfile }}>

--- a/data/stores.js
+++ b/data/stores.js
@@ -39,12 +39,13 @@ export function editStore(store) {
 }
 
 export function favoriteStore(storeId) {
-  return fetchWithoutResponse(`stores/${storeId}/favorite`, {
+  return fetchWithoutResponse(`profile/favoritesellers`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
+    body: JSON.stringify({"store_id": storeId})
   })
 }
 

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -25,14 +25,14 @@ export default function Profile() {
     })
   }, [])
 
-console.log(profile)
+console.log(profile.favorite_sellers)
   return (
     <>
       <CardLayout title="Favorite Stores" width="is-full">
         <div className="columns is-multiline">
           {
             profile.favorite_sellers?.map(favorite => (
-              <StoreCard store={favorite} key={favorite.id} width="is-one-third" />
+              <StoreCard store={favorite} showProductCards={false} key={favorite.id} width="is-one-third" />
             ))
           }
         </div>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -25,13 +25,13 @@ export default function Profile() {
     })
   }, [])
 
-
+console.log(profile)
   return (
     <>
       <CardLayout title="Favorite Stores" width="is-full">
         <div className="columns is-multiline">
           {
-            profile.favorites?.map(favorite => (
+            profile.favorite_sellers?.map(favorite => (
               <StoreCard store={favorite} key={favorite.id} width="is-one-third" />
             ))
           }

--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -24,6 +24,8 @@ export default function StoreDetail() {
     }
   }, [id, profile])
 
+  console.log(profile)
+
   const refresh = () => getStoreById(id).then(storeData => {
     if (storeData) {
       setStore(storeData)

--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -24,8 +24,6 @@ export default function StoreDetail() {
     }
   }, [id, profile])
 
-  console.log(profile)
-
   const refresh = () => getStoreById(id).then(storeData => {
     if (storeData) {
       setStore(storeData)

--- a/pages/stores/new.js
+++ b/pages/stores/new.js
@@ -8,7 +8,6 @@ import StoreForm from '../../components/store/form'
 
 export default function NewStore() {
   const { setProfile, profile } = useAppContext()
-
   const nameEl = useRef()
   const descriptionEl = useRef()
   const router = useRouter()


### PR DESCRIPTION
##Overview:
This pull request introduces the client-side changes required by Ticket #13. The implementation focuses on enabling users to mark stores as favorites directly from the client interface and view their favorite stores on their profile. Users can now easily add a store to their favorites list via the UI, which sends a request to the backend, and see the updated favorites list in real time in their profile view.

##Changes:
API Integration:
- Integrated a client-side POST request to /profile/favoritesellers when the favorite button is clicked.
- The request sends the store_id in the request body to add the store to the user’s favorites list.

Store Card:
- Added showProductCard prop to the profile view and passed it into the store card. Modified the store card as well to take the prop and dynamically render the store product cards based on view.

User Profile View:
- Dynamically shows a list of favorite sellers based on the profile api returned response. 

##Testing
- [x] Log in with a known username and password
- [x] Select Shops
- [x] View the "Culinary Corner" store
- [x] Favorite the store
- [x] Navigate to the profile page via the image icon in the right of the Navbar
- [x] Verify that the store you favorited is in the Favorite Stores list.

##Related Issues:
Ticket #13 