### PR TITLE
Fixed dynamic updating of profile in context state to update when a n…

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -44,7 +44,7 @@ export default function Navbar() {
               <Link href="/stores/new" className="navbar-item">Interested in selling?</Link>
           }
           <hr className="navbar-divider"></hr>
-          <a className="navbar-item" onClick={
+          <Link href='/login' className="navbar-item" onClick={
             () => {
               localStorage.removeItem('token')
               setIsLoggedIn(false)
@@ -52,7 +52,7 @@ export default function Navbar() {
             }}
           >
             Log out
-          </a>
+          </Link>
         </div>
       </div>
     )

--- a/context/state.js
+++ b/context/state.js
@@ -10,7 +10,10 @@ export function AppWrapper({ children }) {
   const router = useRouter()
 
   useEffect(() => {
-    setToken(localStorage.getItem('token'))
+    const storedToken = localStorage.getItem('token')
+    if (storedToken){
+      setToken(storedToken)
+    }
   }, [])
 
   useEffect(() => {
@@ -24,8 +27,10 @@ export function AppWrapper({ children }) {
           }
         })
       }
+    }else {
+      setProfile({})
     }
-  }, [token])
+  }, [token, router.pathname])
 
   return (
     <AppContext.Provider value={{ profile, token, setToken, setProfile }}>

--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -24,6 +24,8 @@ export default function StoreDetail() {
     }
   }, [id, profile])
 
+  console.log(profile)
+
   const refresh = () => getStoreById(id).then(storeData => {
     if (storeData) {
       setStore(storeData)

--- a/pages/stores/new.js
+++ b/pages/stores/new.js
@@ -8,7 +8,6 @@ import StoreForm from '../../components/store/form'
 
 export default function NewStore() {
   const { setProfile, profile } = useAppContext()
-
   const nameEl = useRef()
   const descriptionEl = useRef()
   const router = useRouter()


### PR DESCRIPTION
##Overview:
Fixed the site state context to dynamically reset the profile to an empty object upon logout to stop the system from rendering views with inaccurate information. 

##Changes:
Modified the state.js file to reset profile to an empty object when there is no token in local storage.

##Testing:

- [ ] Register a new user
- [ ] Navigate to "Interested in Selling" under the profile icon on the right of the navbar
- [ ] Complete the form to create a new store
- [ ] Verify that the store you created details are showing
- [ ] Logout
- [ ] Log in as an existing user that is not the user you created in the previous step
- [ ] If the user has a store, navigate to the My Store page and verify that the store details are the details that belong to the current user and not the user you created earlier. If the user has no store, the fix was implemented correctly if "Interested in Selling" shows under the profile icon.

##Related Issues:
Ticker #56 