### PR TITLE
Clear Review Textbox after submitting a Review on a Product

### DIFF
--- a/components/rating/form.js
+++ b/components/rating/form.js
@@ -12,9 +12,11 @@ export default function RatingForm({ saveRating }) {
       rating: outOf5,
       review: comment
     })
+    setComment("")
+    setRating(0)
   }
 
-  useEffect(()=>{setShowRating(true)}, [])
+  useEffect(()=>{setShowRating(true)}, [submitRating])
 
 
 


### PR DESCRIPTION
# Add Reviews and clear review textarea after submitting review

## Changes

- Added resetting state of comment in `submitRating` function in `components/rating/form.js`

## Testing

- [ ] Login as any user
- [ ] On Products page, click into any product details view
- [ ] Give the product a star rating and type a review, click "Post Rating"
- [ ] Verify that the textarea for review is cleared after submitting and that the review is displaying under the review textarea
- [ ] The same user can also update their rating value and review text on the same product

## Related Issues

- Fixes #73 