### PR TITLE
Feature: Unfavorite Store

### DIFF
--- a/data/stores.js
+++ b/data/stores.js
@@ -50,7 +50,7 @@ export function favoriteStore(storeId) {
 }
 
 export function unfavoriteStore(storeId) {
-  return fetchWithoutResponse(`stores/${storeId}/unfavorite`, {
+  return fetchWithoutResponse(`profile/${storeId}/unfavorite`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,


### PR DESCRIPTION
# Feature: Unfavorite Store

## Why

- Users are now able to unfavorite a store

## How

- Fixed endpoint in `data/stores.js` on unfavoriteStore function to go through `profile/{store id}/unfavorite`

## Testing

- [ ] Make sure you are running the backend branch for `feature/unfavoriteStore` and seed the database by running `poetry run ./seed_data.sh` in your terminal
- [ ] Login as Brenda: username: `brenda`, password: `Admin8*`
- [ ] Go to "Profile" via dropdown menu on the right, there should be 3 stores in "Favorite Stores"
- [ ] Click "View Store" on store 2 "Culinary Corner" and verify that the button on the top right says "Unfavorite Store"
- [ ] Click "Unfavorite Store" and verify that the button now displays "Favorite Store"
- [ ] Go back to Profile view and verify that the store "Culinary Corner" no longer displays under "Favorite Stores" section

## Related Issues

Fixes #78  and #79 